### PR TITLE
Add dotenv - Protect my secret data in .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ yarn-debug.log*
 !/tmp/.keep
 !/tmp/pids
 !/tmp/pids/.keep
+.env*


### PR DESCRIPTION
To ensure the secret key provided by cloudinary does not appear in GitHub!